### PR TITLE
Ignore .egg-info dir for editable installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 MANIFEST
 build/
 dist/
+*.egg-info


### PR DESCRIPTION
This is a ignore for when using the editable installation. The editable installation allows to install testimony and every change done in the source reflects to the installation.

To create an editable installation of testimony just cd into the testimony root dir and use the commend `pip install -e .`. For now on every change done to the source will reflect in the `testimony` command without needing to uninstall and install again.

The ignored dir is generated to control this type of installation.
