### PR TITLE
Add JSON output

### DIFF
--- a/testimony/__init__.py
+++ b/testimony/__init__.py
@@ -6,6 +6,7 @@ DocString manipulation methods to create test reports
 """
 
 import ast
+import json
 import os
 import sys
 
@@ -14,7 +15,9 @@ from testimony.constants import (
     CLR_ERR, CLR_GOOD, CLR_RESOURCE, DOCSTRING_TAGS, PRINT_AUTO_TC,
     PRINT_DOC_MISSING, PRINT_INVALID_DOC, PRINT_MANUAL_TC, PRINT_NO_DOC,
     PRINT_NO_MINIMUM_DOC, PRINT_NO_MINIMUM_DOC_TC,
-    PRINT_PARSE_ERR, PRINT_TC_AFFECTED_BUGS, PRINT_TOTAL_TC, REPORT_TAGS)
+    PRINT_PARSE_ERR, PRINT_TC_AFFECTED_BUGS, PRINT_TOTAL_TC, PRINT_REPORT,
+    SUMMARY_REPORT, VALIDATE_DOCSTRING_REPORT, BUGS_REPORT, MANUAL_REPORT,
+    AUTO_REPORT)
 
 try:
     import termcolor
@@ -23,87 +26,167 @@ except ImportError, e:
     has_termcolor = False
 
 settings = {
+    'json': False,
     'nocolor': False,
 }
 
 
-def main(report, paths, nocolor):
+class Result(object):
+    """Class that represents a path result"""
+
+    def __init__(self, bugs=0, bugs_list=[], invalid_docstring=0,
+                 no_docstring=0, no_minimal_docstring=0, manual_count=0,
+                 tc_count=0):
+        """
+        bugs: number of bugs found
+        bugs_list: list of bugs found
+        invalid_docstrings: number of testcases with invalid docstrings found
+        no_docstring: number of testcases with no docstring
+        no_minimal_docstring: number of testcases that don't have at least
+            feature, test and assert tags
+        manual_count: number of testcases that represents manual testing
+        tc_count: total number of testcases found
+        """
+
+        self.bugs = bugs
+        self.bugs_list = bugs_list
+        self.invalid_docstring = invalid_docstring
+        self.no_docstring = no_docstring
+        self.no_minimal_docstring = no_minimal_docstring
+        self.manual_count = manual_count
+        self.tc_count = tc_count
+        self.paths = []
+
+
+def main(report, paths, json, nocolor):
     """
     Main function for testimony project
 
     Expects a valid report type and valid directory paths, hopefully argparse
     is taking care of validation
     """
+
+    settings['json'] = json
     settings['nocolor'] = nocolor
-    result = {
-        'bugs': 0,
-        'bugs_list': list(),
-        'invalid_docstring': 0,
-        'no_docstring': 0,
-        'no_minimal_docstring': 0,
-        'manual_count': 0,
-        'tc_count': 0,
-        }
+    results = []
 
     for path in paths:
-        result = reset_counts(result)
+        result = Result()
         for dirpath, dirnames, filenames in os.walk(path):
-            print colored(
-                "\nFetching Test Path %s\n",
-                attrs=['bold']) % colored(dirpath, CLR_RESOURCE)
+            dir_contents = {
+                'path': dirpath,
+                'files': [],
+            }
+
             for filename in filenames:
                 if (filename.startswith('test_') and
                         filename.endswith('.py')):
-                    #Do not print this text for test summary
-                    if report != REPORT_TAGS[1]:
-                        print colored(
-                            "Scanning %s...", attrs=['bold']) % filename
                     filepath = os.path.join(dirpath, filename)
                     list_strings, result = get_docstrings(
                         report, filepath, result)
-                    if report != REPORT_TAGS[1]:
-                        print_testcases(report, list_strings, result)
-                    else:
+                    dir_contents['files'].append({
+                        'name': filename,
+                        'docstrings': list_strings,
+                    })
+                    if report == SUMMARY_REPORT:
                         #for printing test summary later
                         result = update_summary(list_strings, result)
+            result.paths.append(dir_contents)
+        results.append(result)
+
+    if json is True:
+        print_json_output(report, results)
+    else:
+        print_text_ouput(report, results)
+
+    #Send error code back to caller
+    if any([r.invalid_docstring != 0 or r.no_docstring != 0 for r in results]):
+        sys.exit(-1)
+
+
+def print_text_ouput(report, results):
+    """Prints the report output in text format"""
+    for result in results:
+        for path in result.paths:
+            print colored(
+                "\nFetching Test Path %s\n",
+                attrs=['bold']) % colored(path['path'], CLR_RESOURCE)
+            for f in path['files']:
+                #Do not print this text for test summary
+                if report != SUMMARY_REPORT:
+                    print colored(
+                        "Scanning %s...", attrs=['bold']) % f['name']
+                if report != SUMMARY_REPORT:
+                    print_testcases(report, f['docstrings'], result)
         #Print for test summary
-        if report == REPORT_TAGS[1]:
+        if report == SUMMARY_REPORT:
             print_summary(result)
         #Print total number of invalid doc strings
-        if report == REPORT_TAGS[2]:
-            if result['invalid_docstring'] == 0:
+        if report == VALIDATE_DOCSTRING_REPORT:
+            if result.invalid_docstring == 0:
                 col = CLR_GOOD
             else:
                 col = CLR_ERR
             print colored(
                 PRINT_INVALID_DOC,
-                attrs=['bold']) % colored(result['invalid_docstring'], col)
-            if result['no_docstring'] == 0:
+                attrs=['bold']) % colored(result.invalid_docstring, col)
+            if result.no_docstring == 0:
                 col = CLR_GOOD
             else:
                 col = CLR_ERR
             print colored(
                 PRINT_NO_DOC,
-                attrs=['bold']) % colored(result['no_docstring'], col)
-            if result['no_minimal_docstring'] == 0:
+                attrs=['bold']) % colored(result.no_docstring, col)
+            if result.no_minimal_docstring == 0:
                 col = CLR_GOOD
             else:
                 col = CLR_ERR
             print colored(
                 PRINT_NO_MINIMUM_DOC_TC,
-                attrs=['bold']) % colored(result['no_minimal_docstring'], col)
+                attrs=['bold']) % colored(result.no_minimal_docstring, col)
         #Print number of test cases affected by bugs and also the list of bugs
-        if report == REPORT_TAGS[3]:
+        if report == BUGS_REPORT:
             print colored(
-                PRINT_TC_AFFECTED_BUGS, attrs=['bold']) % result['bugs']
-            if len(result["bug_list"]) > 0:
+                PRINT_TC_AFFECTED_BUGS, attrs=['bold']) % result.bugs
+            if len(result.bugs_list) > 0:
                 print colored("\nBug list:", attrs=['bold'])
-                for bug in result["bug_list"]:
+                for bug in result.bugs_list:
                     print bug
-        #Send error code back to caller
-        if (result['invalid_docstring'] != 0 or result['no_docstring'] != 0
-                or result['no_minimal_docstring'] != 0):
-            sys.exit(-1)
+
+
+def print_json_output(report, results):
+    """Prints the report output in JSON format"""
+
+    if report == PRINT_REPORT:
+        output = [result.paths for result in results]
+    elif report == SUMMARY_REPORT:
+        output = [get_summary_result(result) for result in results]
+    elif report == VALIDATE_DOCSTRING_REPORT:
+        output = [result.__dict__ for result in results]
+    elif report == BUGS_REPORT:
+        output = [{'bugs': result.bugs,
+                   'bugs_list': result.bugs_list} for result in results]
+    elif report == MANUAL_REPORT or report == AUTO_REPORT:
+        for result in results:
+            for path in result.paths:
+                for f in path['files']:
+                    docstrings = []
+                    for docstring in f['docstrings']:
+                        status_tag = False
+                        for line in docstring:
+                            tag = line.split(' ', 1)[0].lower()
+                            if DOCSTRING_TAGS[6] in tag:
+                                status_tag = True
+                        if ((report == AUTO_REPORT and not status_tag) or
+                                (report == MANUAL_REPORT and status_tag)):
+                            docstrings.append(docstring)
+                    f['docstrings'] = docstrings
+        output = [result.paths for result in results]
+    else:
+        # Will not get here because argparse validation, but just to make sure
+        raise Exception('Report %s not available' % report)
+
+    print json.dumps(output)
 
 
 def get_docstrings(report, path, result):
@@ -145,7 +228,7 @@ def get_docstrings(report, path, result):
                             #Remove any new line characters
                             attr = attr.rstrip('\n')
                             if attr != '':
-                                if report == REPORT_TAGS[2]:
+                                if report == VALIDATE_DOCSTRING_REPORT:
                                     docstring_tag = attr.split(" ", 1)
                                     #Error out invalid docstring
                                     if not any(
@@ -156,8 +239,7 @@ def get_docstrings(report, path, result):
                                             % (func_name, colored(
                                                 attr, CLR_ERR,
                                                 attrs=['bold'])))
-                                        result['invalid_docstring'] = result[
-                                            'invalid_docstring'] + 1
+                                        result.invalid_docstring += 1
                                     if (DOCSTRING_TAGS[0] in
                                             docstring_tag[0].lower()):
                                         featurefound = True
@@ -167,36 +249,35 @@ def get_docstrings(report, path, result):
                                     if (DOCSTRING_TAGS[4] in
                                             docstring_tag[0].lower()):
                                         assertfound = True
-                                elif report == REPORT_TAGS[3]:
+                                elif report == BUGS_REPORT:
                                     #Find the bug from docstring
                                     docstring_tag = attr.split(" ", 1)
-                                    if DOCSTRING_TAGS[5] in \
-                                            docstring_tag[0].lower():
+                                    if (DOCSTRING_TAGS[5] in
+                                            docstring_tag[0].lower()):
                                         item_list.append(attr)
-                                        result['bugs'] = result['bugs'] + 1
-                                        result['bug_list'].append(
+                                        result.bugs += 1
+                                        result.bugs_list.append(
                                             docstring_tag[1])
                                 else:
                                     #For printing all test cases
                                     item_list.append(attr)
-                        if report == REPORT_TAGS[2]:
+                        if report == VALIDATE_DOCSTRING_REPORT:
                             if (not featurefound or
                                     not testfound or
                                     not assertfound):
                                 item_list.append(
                                     "%s: %s" % (
                                         func_name, PRINT_NO_MINIMUM_DOC))
-                                result['no_minimal_docstring'] =\
-                                    result['no_minimal_docstring'] + 1
+                                result.no_minimal_docstring += 1
                         if len(item_list) != 0:
                             return_list.append(item_list)
         except AttributeError:
-            if report == REPORT_TAGS[0] or report == REPORT_TAGS[2]:
+            if report == PRINT_REPORT or report == VALIDATE_DOCSTRING_REPORT:
                 item_list.append(
                     "%s: %s" % (
                         func_name, colored(PRINT_DOC_MISSING, CLR_ERR)))
                 return_list.append(item_list)
-            result['no_docstring'] = result['no_docstring'] + 1
+            result.no_docstring += 1
             continue
         except:
             print colored(PRINT_PARSE_ERR, CLR_ERR, attrs=['bold'])
@@ -209,7 +290,7 @@ def print_testcases(report, list_strings, result):
     """
     tc = 0
     for docstring in list_strings:
-        if report == REPORT_TAGS[0]:
+        if report == PRINT_REPORT:
             tc = tc + 1
             print "\nTC %d" % tc
 
@@ -218,17 +299,17 @@ def print_testcases(report, list_strings, result):
         auto_print = True
         for lineitem in docstring:
             docstring_tag = lineitem.split(" ", 1)
-            if report == REPORT_TAGS[5]:
+            if report == AUTO_REPORT:
                 if DOCSTRING_TAGS[6] in docstring_tag[0].lower():
                     auto_print = False
-            if report == REPORT_TAGS[4]:
+            if report == MANUAL_REPORT:
                 if DOCSTRING_TAGS[6] in docstring_tag[0].lower():
                     manual_print = True
-        if report == REPORT_TAGS[5] and auto_print is True:
+        if report == AUTO_REPORT and auto_print is True:
             print_line_item(docstring)
-        if report == REPORT_TAGS[4] and manual_print is True:
+        if report == MANUAL_REPORT and manual_print is True:
             print_line_item(docstring)
-        if report == REPORT_TAGS[0] or report == REPORT_TAGS[2]:
+        if report == PRINT_REPORT or report == VALIDATE_DOCSTRING_REPORT:
             print_line_item(docstring)
 
 
@@ -237,41 +318,44 @@ def update_summary(list_strings, result):
     Updates summary for reporting
     """
     for docstring in list_strings:
-        result['tc_count'] = result['tc_count'] + 1
+        result.tc_count += 1
         for lineitem in docstring:
             lineitem = lineitem.lower()
             if lineitem.startswith(DOCSTRING_TAGS[6]) and 'manual' in lineitem:
-                result['manual_count'] = result['manual_count'] + 1
+                result.manual_count += 1
     return result
+
+
+def get_summary_result(result):
+    manual_percent = float(Decimal(result.manual_count) /
+                           Decimal(result.tc_count) * 100)
+    auto_count = result.tc_count - result.manual_count
+    auto_percent = float(Decimal(int(auto_count)) / Decimal(result.tc_count) *
+                         100)
+    return {
+        'tc_count': result.tc_count,
+        'auto_count': auto_count,
+        'auto_percent': auto_percent,
+        'manual_count': result.manual_count,
+        'manual_percent': manual_percent,
+        'no_docstring': result.no_docstring,
+    }
 
 
 def print_summary(result):
     """
     Prints summary for reporting
     """
-    manual_percent = (Decimal(result['manual_count']) /
-                      Decimal(result['tc_count']))
-    auto_count = result['tc_count'] - result['manual_count']
-    auto_percent = Decimal(int(auto_count)) / Decimal(result['tc_count'])
-    print colored(PRINT_TOTAL_TC, attrs=['bold']) % result['tc_count']
-    print (colored(PRINT_AUTO_TC, attrs=['bold']) % auto_count +
-           '({0:.0%})'.format(auto_percent))
-    print (colored(PRINT_MANUAL_TC, attrs=['bold']) % result['manual_count'] +
-           '({0:.0%})'.format(manual_percent))
-    print colored(PRINT_NO_DOC, attrs=['bold']) % result['no_docstring']
-
-
-def reset_counts(result):
-    """
-    Resets all the counts to switch between UI and CLI reports
-    """
-    result['tc_count'] = 0
-    result['manual_count'] = 0
-    result['no_docstring'] = 0
-    result['invalid_docstring'] = 0
-    result['bugs'] = 0
-    result['bug_list'] = []
-    return result
+    summary_result = get_summary_result(result)
+    print colored(PRINT_TOTAL_TC, attrs=['bold']) % summary_result['tc_count']
+    print (colored(PRINT_AUTO_TC, attrs=['bold']) %
+           summary_result['auto_count'] +
+           '({0:.0f}%)'.format(summary_result['auto_percent']))
+    print (colored(PRINT_MANUAL_TC, attrs=['bold']) %
+           summary_result['manual_count'] +
+           '({0:.0f}%)'.format(summary_result['manual_percent']))
+    print (colored(PRINT_NO_DOC, attrs=['bold']) %
+           summary_result['no_docstring'])
 
 
 def print_line_item(docstring):

--- a/testimony/__main__.py
+++ b/testimony/__main__.py
@@ -29,7 +29,9 @@ if __name__ == "__main__":
         'paths', metavar='PATH', type=dir_arg, nargs='+',
         help='a list of paths to look for tests cases')
     parser.add_argument(
+        '-j', '--json', action='store_true', help='JSON output')
+    parser.add_argument(
         '-n', '--nocolor', action='store_true', help='Do not use color option')
 
     args = parser.parse_args()
-    main(args.report, args.paths, args.nocolor)
+    main(args.report, args.paths, args.json, args.nocolor)

--- a/testimony/constants.py
+++ b/testimony/constants.py
@@ -20,13 +20,21 @@ DOCSTRING_TAGS = [
     'bz',
     'status']
 
-REPORT_TAGS = [
-    'print',
-    'summary',
-    'validate_docstring',
-    'bugs',
-    'manual',
-    'auto']
+PRINT_REPORT = 'print'
+SUMMARY_REPORT = 'summary'
+VALIDATE_DOCSTRING_REPORT = 'validate_docstring'
+BUGS_REPORT = 'bugs'
+MANUAL_REPORT = 'manual'
+AUTO_REPORT = 'auto'
+
+REPORT_TAGS = (
+    PRINT_REPORT,
+    SUMMARY_REPORT,
+    VALIDATE_DOCSTRING_REPORT,
+    BUGS_REPORT,
+    MANUAL_REPORT,
+    AUTO_REPORT,
+)
 
 PRINT_TOTAL_TC = 'Total Number of test cases:      %s'
 PRINT_AUTO_TC = 'Total Number of automated cases: %d '


### PR DESCRIPTION
- Add --json flag to testimony command for JSON output
- Create a Result class to hold the result info for each PATH
- Logic refactor to process the docstrings and then print the results
- Update report type constants to a more verbose constant name
- Fix a bug to process all PATHS before exiting with return code -1
