### PR TITLE
Add root path to JSON summary output

### DIFF
--- a/testimony/__init__.py
+++ b/testimony/__init__.py
@@ -333,6 +333,7 @@ def get_summary_result(result):
     auto_percent = float(Decimal(int(auto_count)) / Decimal(result.tc_count) *
                          100)
     return {
+        'path': result.paths[0]['path'],  # get the root path
         'tc_count': result.tc_count,
         'auto_count': auto_count,
         'auto_percent': auto_percent,


### PR DESCRIPTION
For consistency with the text output and to help generate identify from with base path is that result (will be useful here https://github.com/elyezer/bem-te-vi/commit/05fde00136ca06361dd2bd72ec458c5f04f32d74)

```
$ testimony summary ~/code/robottelo/tests/api ~/code/robottelo/tests/cli ~/code/robottelo/tests/ui

Fetching Test Path /Users/elyezer/code/robottelo/tests/api

Total Number of test cases:      91
Total Number of automated cases: 24 (26%)
Total Number of manual cases:    67 (74%)
Test cases with no docstrings:   0

Fetching Test Path /Users/elyezer/code/robottelo/tests/cli

Total Number of test cases:      372
Total Number of automated cases: 114 (31%)
Total Number of manual cases:    258 (69%)
Test cases with no docstrings:   0

Fetching Test Path /Users/elyezer/code/robottelo/tests/ui

Total Number of test cases:      380
Total Number of automated cases: 102 (27%)
Total Number of manual cases:    278 (73%)
Test cases with no docstrings:   0
```

```
$ testimony summary -j ~/code/robottelo/tests/api ~/code/robottelo/tests/cli ~/code/robottelo/tests/ui
[{"auto_count": 24, "manual_count": 67, "auto_percent": 26.373626373626372, "no_docstring": 0, "path": "/Users/elyezer/code/robottelo/tests/api", "tc_count": 91, "manual_percent": 73.62637362637362}, {"auto_count": 114, "manual_count": 258, "auto_percent": 30.64516129032258, "no_docstring": 0, "path": "/Users/elyezer/code/robottelo/tests/cli", "tc_count": 372, "manual_percent": 69.35483870967742}, {"auto_count": 102, "manual_count": 278, "auto_percent": 26.842105263157894, "no_docstring": 0, "path": "/Users/elyezer/code/robottelo/tests/ui", "tc_count": 380, "manual_percent": 73.15789473684211}]
```
