### PR TITLE
General formating improvement

### DIFF
--- a/testimony/__init__.py
+++ b/testimony/__init__.py
@@ -1,9 +1,5 @@
 # -*- encoding: utf-8 -*-
-# vim: ts=4 sw=4 expandtab ai
-
-"""
-DocString manipulation methods to create test reports
-"""
+"""DocString manipulation methods to create test reports"""
 
 import ast
 import json
@@ -37,8 +33,7 @@ class Result(object):
     def __init__(self, bugs=0, bugs_list=[], invalid_docstring=0,
                  no_docstring=0, no_minimal_docstring=0, manual_count=0,
                  tc_count=0):
-        """
-        bugs: number of bugs found
+        """bugs: number of bugs found
         bugs_list: list of bugs found
         invalid_docstrings: number of testcases with invalid docstrings found
         no_docstring: number of testcases with no docstring
@@ -46,6 +41,7 @@ class Result(object):
             feature, test and assert tags
         manual_count: number of testcases that represents manual testing
         tc_count: total number of testcases found
+
         """
 
         self.bugs = bugs
@@ -59,11 +55,11 @@ class Result(object):
 
 
 def main(report, paths, json, nocolor):
-    """
-    Main function for testimony project
+    """Main function for testimony project
 
     Expects a valid report type and valid directory paths, hopefully argparse
     is taking care of validation
+
     """
 
     settings['json'] = json
@@ -190,9 +186,7 @@ def print_json_output(report, results):
 
 
 def get_docstrings(report, path, result):
-    """
-    Function to read docstrings from test_*** methods for a given file
-    """
+    """Function to read docstrings from test_*** methods for a given file"""
     return_list = []
     obj = ast.parse(''.join(open(path)))
     # The body field inside obj.body[] contains the docstring
@@ -285,9 +279,7 @@ def get_docstrings(report, path, result):
 
 
 def print_testcases(report, list_strings, result):
-    """
-    Prints all the test cases based on given criteria
-    """
+    """Prints all the test cases based on given criteria"""
     tc = 0
     for docstring in list_strings:
         if report == PRINT_REPORT:
@@ -314,9 +306,7 @@ def print_testcases(report, list_strings, result):
 
 
 def update_summary(list_strings, result):
-    """
-    Updates summary for reporting
-    """
+    """Updates summary for reporting"""
     for docstring in list_strings:
         result.tc_count += 1
         for lineitem in docstring:
@@ -344,9 +334,7 @@ def get_summary_result(result):
 
 
 def print_summary(result):
-    """
-    Prints summary for reporting
-    """
+    """Prints summary for reporting"""
     summary_result = get_summary_result(result)
     print colored(PRINT_TOTAL_TC, attrs=['bold']) % summary_result['tc_count']
     print (colored(PRINT_AUTO_TC, attrs=['bold']) %
@@ -360,17 +348,13 @@ def print_summary(result):
 
 
 def print_line_item(docstring):
-    """
-    Parses the given docstring list to print out each line item
-    """
+    """Parses the given docstring list to print out each line item"""
     for lineitem in docstring:
         print lineitem
 
 
 def colored(text, color=None, attrs=None):
-    """
-    Checks if termcolor is installed before calling it
-    """
+    """Checks if termcolor is installed before calling it"""
     if has_termcolor and not settings['nocolor']:
         return termcolor.colored(text, color=color, attrs=attrs)
     else:

--- a/testimony/__main__.py
+++ b/testimony/__main__.py
@@ -1,6 +1,4 @@
 # -*- encoding: utf-8 -*-
-# vim: ts=4 sw=4 expandtab ai
-
 import argparse
 import os.path
 

--- a/testimony/constants.py
+++ b/testimony/constants.py
@@ -1,9 +1,5 @@
 # -*- encoding: utf-8 -*-
-# vim: ts=4 sw=4 expandtab ai
-
-"""
-Defines various constants
-"""
+"""Defines various constants"""
 
 # Per termcolor webpage, these are the available colors:
 # grey, red, green, yellow, blue, magenta, cyan, white

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,29 +1,29 @@
 # -*- encoding: utf-8 -*-
-# vim: ts=4 sw=4 expandtab ai
-
-"""
-Test class for Sample Test
-"""
+"""Test class for Sample Test"""
 
 
 class Testsample():
-    """
-    This is a dummy test file used for testing testimony
-    """
+    """This is a dummy test file used for testing testimony"""
 
     # Test with incorrect doctrings:
     # Feture vs. Feature, Statues vs. Status,
     # Statues vs. Status
     # bug vs bz
     def test_positive_login_1(self):
-        """
+        """@Test: Login with right credentials
+
         @Feture: Login - Positive
-        @Test: Login with right credentials
+
         @Steps:
+
         1. Login to the application with valid credentials
+
         @Assert: Login is successful
+
         @Bug: 123456
+
         @Statues: Manual
+
         """
         # Code to perform the test
         pass
@@ -35,36 +35,48 @@ class Testsample():
 
     # Test with all required docstrings and is automated
     def test_positive_login_3(self):
-        """
+        """@Test: Login with Latin credentials
+
         @Feature: Login - Positive
-        @Test: Login with Latin credentials
+
         @Steps:
+
         1. Login to the application with valid Latin credentials
+
         @Assert: Login is successful
+
         """
         # Code to perform the test
         pass
 
     # Test with all required docstrings and is manual
     def test_positive_login_4(self):
-        """
+        """@Test: Login with Credentials having special characters
+
         @Feature: Login - Positive
-        @Test: Login with Credentials having special characters
+
         @Steps:
+
         1. Login to the application with valid credentials having
         special characters
+
         @Assert: Activation key is created
+
         @Status: Manual
+
         """
         # Code to perform the test
         pass
 
 # Test missing required docstrings
     def test_negative_login_5(self):
-        """
-        @Steps:
+        """@Steps:
+
         1. Login to the application with invalid credentials
+
         @BZ: 123456
+
         @Status: Manual
+
         """
         # Login to the application


### PR DESCRIPTION
Use the recommended docstring formatting for one line and multi-lines
docstrings.

Update sample test case's methods docstrings formatting to be as close
as possible to the one suggested on the README.

Remove editor options line comment