### PR TITLE
Fix JSON output

### DIFF
--- a/testimony/__init__.py
+++ b/testimony/__init__.py
@@ -93,7 +93,7 @@ def main(report, paths, json_output, nocolor):
             result.paths.append(dir_contents)
         results.append(result)
 
-    if json is True:
+    if SETTINGS['json'] is True:
         print_json_output(report, results)
     else:
         print_text_ouput(report, results)


### PR DESCRIPTION
In previous refactor the main function json argument was renamed to
json_output. During the change was missed to update the var name when
checking for JSON output. This fixes that but instead of using the
updated var name, the option is being read from the SETTINGS.

Closes #69