### PR TITLE
Use docstring for @Test if tag does not exist

### DIFF
--- a/testimony/__init__.py
+++ b/testimony/__init__.py
@@ -124,6 +124,7 @@ class TestFunction(object):
                 else:
                     self.skipped_lines.append(line)
 
+        # if @Test tag not found, use the first line of docstring
         if self.test is None:
             self.test = self.docstring.strip().split('\n')[0]
 

--- a/testimony/__init__.py
+++ b/testimony/__init__.py
@@ -124,6 +124,9 @@ class TestFunction(object):
                 else:
                     self.skipped_lines.append(line)
 
+        if self.test is None:
+            self.test = self.docstring.strip().split('\n')[0]
+
     @property
     def automated(self):
         """Indicate if the test case is automated or not."""


### PR DESCRIPTION
If @Test does not exist, use the first line of the docstring
for test.  This can allow a user to define the test case name
on the first line of the docstring and not have to strip the
@Test tag.

Signed-off-by: Scott Poore <spoore@redhat.com>