### PR TITLE
Accept both file and dir path

### DIFF
--- a/testimony/__init__.py
+++ b/testimony/__init__.py
@@ -61,6 +61,13 @@ def indent(text, prefix, predicate=None):
     return ''.join(prefixed_lines())
 
 
+def is_test_module(filename):
+    """Return ``True`` if the ``filename`` matches an expected test
+    module name.
+    """
+    return filename.startswith('test_') and filename.endswith('.py')
+
+
 class TestFunction(object):
     """Class that wraps a ``ast.FunctionDef`` instance and provide useful
     information for creating the reports.
@@ -508,9 +515,14 @@ def get_testcases(paths):
     """
     testmodules = []
     for path in paths:
+        if os.path.isfile(path):
+            filename = os.path.basename(path)
+            if is_test_module(filename):
+                    testmodules.append(path)
+            continue
         for dirpath, _, filenames in os.walk(path):
             for filename in filenames:
-                if filename.startswith('test_') and filename.endswith('.py'):
+                if is_test_module(filename):
                     testmodules.append(os.path.join(dirpath, filename))
     testcases = collections.OrderedDict()
     for testmodule in testmodules:

--- a/testimony/__main__.py
+++ b/testimony/__main__.py
@@ -8,12 +8,12 @@ from testimony import main
 from testimony.constants import REPORT_TAGS
 
 
-def dir_arg(arg):
-    """Checks if a path argument is a directory"""
-    if os.path.isdir(arg):
+def file_or_dir_arg(arg):
+    """Checks if a path argument is a file or a directory."""
+    if os.path.isdir(arg) or os.path.isfile(arg):
         return arg
     else:
-        msg = '%s is not a directory' % arg
+        msg = '%s is not a file or a directory' % arg
         raise argparse.ArgumentTypeError(msg)
 
 
@@ -27,7 +27,7 @@ def parse_args():
         metavar='REPORT',
         help='report type, possible values: %s' % ', '.join(REPORT_TAGS))
     parser.add_argument(
-        'paths', metavar='PATH', type=dir_arg, nargs='+',
+        'paths', metavar='PATH', type=file_or_dir_arg, nargs='+',
         help='a list of paths to look for tests cases')
     parser.add_argument(
         '-j', '--json', action='store_true', help='JSON output')


### PR DESCRIPTION
Make testimony accept not only directories but also files as input paths
to generate reports.

Closes #35 

Sample run:

```
testimony  print ../robottelo/tests/foreman/api/test_rhsm.py ../robottelo/tests/foreman/cli/test_abrt.py  
../robottelo/tests/foreman/api/test_rhsm.py
===========================================

TC 1
Test: Check whether the path exists.
Feature: Red Hat Subscription Manager
Assert: Issuing an HTTP GET produces an HTTP 200 response with an
``application/json`` content-type, and the response is a list.
This test targets bugzilla bug 1112802.

../robottelo/tests/foreman/cli/test_abrt.py
===========================================

TC 1
Test: a crashed program and abrt reports are send
Feature: Abrt
Assert: A abrt report with ccpp.* extension  created under
/var/tmp/abrt
Setup: abrt
Steps: 1. start a sleep process in background, kill it send the report using
smart-proxy-abrt-send
Status: Manual

TC 2
Test: Counts are correct when abrt sends multiple reports
Feature: Abrt
Assert: Count is updated in proper manner
Setup: abrt
Steps: 1. Create multiple reports of abrt
2. Keep track of counts
Status: Manual

TC 3
Test: Edit the smart-proxy-abrt timer
Feature: Abrt
Assert: the timer file is edited
Setup: abrt
Steps: 1. edit the timer for /etc/cron.d/rubygem-smart_proxy_abrt
Status: Manual

TC 4
Test: Identifying the hostnames
Feature: Abrt
Assert: Assertion of hostnames is possible
Setup: abrt
Steps: 1. UI => Settings => Abrt tab => edit hostnames
Status: Manual

TC 5
Test: Able to retrieve reports in CLI
Feature: Abrt
Assert: Assertion of parameters
Setup: abrt
Steps: 1. access /var/tmp/abrt/ccpp-* files
Status: Manual
```