### PR TITLE
Remove proxy call from TestFunction

### DIFF
--- a/testimony/__init__.py
+++ b/testimony/__init__.py
@@ -85,9 +85,10 @@ class TestFunction(object):
 
     def __init__(self, function_def, parent_class=None, testmodule=None):
         #: A ``ast.FunctionDef`` instance used to extract information
-        self.function_def = function_def
-        self.parent_class = parent_class
         self.docstring = ast.get_docstring(function_def)
+        self.function_def = function_def
+        self.name = function_def.name
+        self.parent_class = parent_class
         self.testmodule = testmodule
         self.assertion = None
         self.bugs = None
@@ -176,14 +177,6 @@ class TestFunction(object):
             'tags': self.tags,
             'test': self.test,
         }
-
-    def __getattr__(self, name):
-        """Proxy missing attributes to the ``ast.FunctionDef`` instance."""
-        attr = getattr(self.function_def, name, self._undefined)
-        if attr is self._undefined:
-            return super(TestFunction, self).__getattr__(name)
-        else:
-            return attr
 
     def __str__(self):
         output = []


### PR DESCRIPTION
This will make testimony play nice when running inside a multiprocessing
environment. That proxy logic lands to a max recursion depth error when
multiprocessing module is trying to pass a TestFunction instance to a
process.

```
===============
= auto report =
===============

tests/test_sample.py
====================

TC 1
Test: Login with right credentials
Assert: Login is successful
Steps: 1. Login to the application with valid credentials
Tags: t1, t2, t3
Skipped lines:
  Feture: Login - Positive
  Bug: 123456
  Statues: Manual

TC 2
Test: Login with Latin credentials
Feature: Login - Positive
Assert: Login is successful
Steps: 1. Login to the application with valid Latin credentials
Tags: t1

TC 3
Test: Login with invalid credentials
Feature: Login - Negative
Assert: Login failed
Steps: 1. Login to the application with valid username and no password


===============
= bugs report =
===============

Test cases affected by 123456
=============================

tests/test_sample.py
--------------------

* test_negative_login_5
* test_negative_login_6


Total Number of test cases affected by bugs: 2/7 (28.57%)

=================
= manual report =
=================

tests/test_sample.py
====================

TC 1
Test: Login with Credentials having special characters
Feature: Login - Positive
Assert: Activation key is created
Steps: 1. Login to the application with valid credentials having
special characters
Status: Manual

TC 2
Test: Test missing required docstrings
Steps: 1. Login to the application with invalid credentials
Bugs: 123456
Status: Manual
Tags: t2

TC 3
Test: Login with invalid credentials
Feature: Login - Negative
Assert: Login failed
Steps: 1. Login to the application with invalid credentials
Bugs: 123456
Status: Manual
Tags: t3


================
= print report =
================

tests/test_sample.py
====================

TC 1
Test: Login with right credentials
Assert: Login is successful
Steps: 1. Login to the application with valid credentials
Tags: t1, t2, t3
Skipped lines:
  Feture: Login - Positive
  Bug: 123456
  Statues: Manual

TC 2


TC 3
Test: Login with Latin credentials
Feature: Login - Positive
Assert: Login is successful
Steps: 1. Login to the application with valid Latin credentials
Tags: t1

TC 4
Test: Login with Credentials having special characters
Feature: Login - Positive
Assert: Activation key is created
Steps: 1. Login to the application with valid credentials having
special characters
Status: Manual

TC 5
Test: Test missing required docstrings
Steps: 1. Login to the application with invalid credentials
Bugs: 123456
Status: Manual
Tags: t2

TC 6
Test: Login with invalid credentials
Feature: Login - Negative
Assert: Login failed
Steps: 1. Login to the application with invalid credentials
Bugs: 123456
Status: Manual
Tags: t3

TC 7
Test: Login with invalid credentials
Feature: Login - Negative
Assert: Login failed
Steps: 1. Login to the application with valid username and no password


==================
= summary report =
==================

Total Number of test cases:      7
Total Number of automated cases: 3 (43%)
Total Number of manual cases:    3 (43%)
Test cases with no docstrings:   1 (14%)

===============
= tags report =
===============

Input tags required for this report.  See testimony --help

=============================
= validate_docstring report =
=============================

tests/test_sample.py
====================

test_positive_login_1
---------------------

* Docstring should have at least feature and assert tags
* Unexpected tags found:
  Feture: Login - Positive
  Bug: 123456
  Statues: Manual

test_positive_login_2
---------------------

* Missing docstring.
* Docstring should have at least feature and assert tags

test_negative_login_5
---------------------

* Docstring should have at least feature and assert tags

Total Number of invalid docstrings:  3/7 (42.86%)
Test cases with no docstrings:   1/7 (14.29%) 
Test cases missing minimal docstrings:  3/7 (42.86%)
Test cases with invalid tags: 1/7 (14.29%)
```