### PR TITLE
Added custom field 'Type'

### DIFF
--- a/testimony/__init__.py
+++ b/testimony/__init__.py
@@ -98,6 +98,7 @@ class TestFunction(object):
         self.steps = None
         self.tags = None
         self.test = None
+        self.test_type = None
         self.skipped_lines = []
         self._parse_docstring()
 
@@ -134,6 +135,8 @@ class TestFunction(object):
                     self.steps = value
                 elif tag == 'tags':
                     self.tags = value
+                elif tag == 'type':
+                    self.test_type = value
                 else:
                     self.skipped_lines.append(line)
 
@@ -176,6 +179,7 @@ class TestFunction(object):
             'steps': self.steps,
             'tags': self.tags,
             'test': self.test,
+            'test_type': self.test_type
         }
 
     def __str__(self):
@@ -196,6 +200,8 @@ class TestFunction(object):
             output.append('Status: ' + self.status)
         if self.tags is not None:
             output.append('Tags: ' + self.tags)
+        if self.test_type is not None:
+            output.append('Type: ' + self.test_type)
         if self.skipped_lines:
             output.append(
                 'Skipped lines:\n' +

--- a/tests/sample_output.txt
+++ b/tests/sample_output.txt
@@ -14,6 +14,7 @@ Skipped lines:
   Feture: Login - Positive
   Bug: 123456
   Statues: Manual
+  Types: Functional
 
 TC 2
 Test: Login with Latin credentials
@@ -75,6 +76,7 @@ Steps: 1. Login to the application with invalid credentials
 Bugs: 123456
 Status: Manual
 Tags: t3
+Type: Functional
 
 
 ================
@@ -93,6 +95,7 @@ Skipped lines:
   Feture: Login - Positive
   Bug: 123456
   Statues: Manual
+  Types: Functional
 
 TC 2
 
@@ -127,6 +130,7 @@ Steps: 1. Login to the application with invalid credentials
 Bugs: 123456
 Status: Manual
 Tags: t3
+Type: Functional
 
 TC 7
 Test: Login with invalid credentials
@@ -165,6 +169,7 @@ test_positive_login_1
   Feture: Login - Positive
   Bug: 123456
   Statues: Manual
+  Types: Functional
 
 test_positive_login_2
 ---------------------

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -26,6 +26,7 @@ class Testsample1():
 
         @Tags: t1, t2, t3
 
+        @Types: Functional
         """
         # Code to perform the test
         pass
@@ -112,6 +113,7 @@ class Testsample2():
 
         @Tags: t3
 
+        @Type: Functional
         """
         # Code to perform the test
         pass


### PR DESCRIPTION
testimony can now parse custom field called 'Type' which takes
argument as one of the - Functional, Non-functional, Structural

Partly fixes: #90 

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>