### PR TITLE
Add context parse management

### DIFF
--- a/tests/sample_output.txt
+++ b/tests/sample_output.txt
@@ -8,6 +8,7 @@ tests/test_sample.py
 TC 1
 Test: Login with right credentials
 Assert: Login is successful
+Setup: Setup Testsample1
 Steps: 1. Login to the application with valid credentials
 Tags: t1, t2, t3
 Skipped lines:
@@ -20,6 +21,7 @@ TC 2
 Test: Login with Latin credentials
 Feature: Login - Positive
 Assert: Login is successful
+Setup: Setup test_positive_login_3
 Steps: 1. Login to the application with valid Latin credentials
 Tags: t1
 
@@ -27,6 +29,7 @@ TC 3
 Test: Login with invalid credentials
 Feature: Login - Negative
 Assert: Login failed
+Setup: Global setup
 Steps: 1. Login to the application with valid username and no password
 
 
@@ -57,12 +60,14 @@ TC 1
 Test: Login with Credentials having special characters
 Feature: Login - Positive
 Assert: Activation key is created
+Setup: Setup Testsample1
 Steps: 1. Login to the application with valid credentials having
 special characters
 Status: Manual
 
 TC 2
 Test: Test missing required docstrings
+Setup: Setup Testsample1
 Steps: 1. Login to the application with invalid credentials
 Bugs: 123456
 Status: Manual
@@ -72,6 +77,7 @@ TC 3
 Test: Login with invalid credentials
 Feature: Login - Negative
 Assert: Login failed
+Setup: Global setup
 Steps: 1. Login to the application with invalid credentials
 Bugs: 123456
 Status: Manual
@@ -89,6 +95,7 @@ tests/test_sample.py
 TC 1
 Test: Login with right credentials
 Assert: Login is successful
+Setup: Setup Testsample1
 Steps: 1. Login to the application with valid credentials
 Tags: t1, t2, t3
 Skipped lines:
@@ -104,6 +111,7 @@ TC 3
 Test: Login with Latin credentials
 Feature: Login - Positive
 Assert: Login is successful
+Setup: Setup test_positive_login_3
 Steps: 1. Login to the application with valid Latin credentials
 Tags: t1
 
@@ -111,12 +119,14 @@ TC 4
 Test: Login with Credentials having special characters
 Feature: Login - Positive
 Assert: Activation key is created
+Setup: Setup Testsample1
 Steps: 1. Login to the application with valid credentials having
 special characters
 Status: Manual
 
 TC 5
 Test: Test missing required docstrings
+Setup: Setup Testsample1
 Steps: 1. Login to the application with invalid credentials
 Bugs: 123456
 Status: Manual
@@ -126,6 +136,7 @@ TC 6
 Test: Login with invalid credentials
 Feature: Login - Negative
 Assert: Login failed
+Setup: Global setup
 Steps: 1. Login to the application with invalid credentials
 Bugs: 123456
 Status: Manual
@@ -136,6 +147,7 @@ TC 7
 Test: Login with invalid credentials
 Feature: Login - Negative
 Assert: Login failed
+Setup: Global setup
 Steps: 1. Login to the application with valid username and no password
 
 

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,9 +1,15 @@
 # -*- encoding: utf-8 -*-
-"""Test class for Sample Test"""
+"""Test class for Sample Test
+
+@Setup: Global setup
+"""
 
 
 class Testsample1():
-    """This is a dummy test file used for testing testimony"""
+    """This is a dummy test file used for testing testimony
+
+    @Setup: Setup Testsample1
+    """
 
     # Test with incorrect doctrings:
     # Feture vs. Feature, Statues vs. Status,
@@ -39,6 +45,8 @@ class Testsample1():
     # Test with all required docstrings and is automated
     def test_positive_login_3(self):
         """Login with Latin credentials
+
+        @Setup: Setup test_positive_login_3
 
         @Feature: Login - Positive
 


### PR DESCRIPTION
Add the concept of contexts when parsing the tests functions' docstring. Now
testimony tags can be added to the module and class level docstrings.

The context resolution will be done in the following order function > class >
module, if a tag is found then the resolution will stop.

Also start storing non recognized tags to improve Testimony usage as a library.

Close #93