### PR TITLE
Improve TestFunction._parse_docstring

### DIFF
--- a/testimony/__init__.py
+++ b/testimony/__init__.py
@@ -127,6 +127,8 @@ class TestFunction(object):
                 ['@unexpected_tag1: value', '@unexpected_tag2: value2']
             )
         """
+        if docstring is None:
+            return {}, {}, []
         valid_tags = [
             'assert',
             'bz',


### PR DESCRIPTION
Avoid raising an exception when receiving `None` as a docstring.

Did some testing with Robottelo tests in order to make sure it is working:

```
$ testimony summary ../robottelo/tests/foreman    
Total Number of test cases:      2601
Total Number of automated cases: 1869 (72%)
Total Number of manual cases:    732 (28%)
Test cases with no docstrings:   0 (0%)

$ testimony summary ../robottelo/tests/foreman/api
Total Number of test cases:      709
Total Number of automated cases: 617 (87%)
Total Number of manual cases:    92 (13%)
Test cases with no docstrings:   0 (0%)

$ testimony summary ../robottelo/tests/foreman/cli
Total Number of test cases:      903
Total Number of automated cases: 692 (77%)
Total Number of manual cases:    211 (23%)
Test cases with no docstrings:   0 (0%)

$ testimony summary ../robottelo/tests/foreman/ui
Total Number of test cases:      933
Total Number of automated cases: 510 (55%)
Total Number of manual cases:    423 (45%)
Test cases with no docstrings:   0 (0%)
```