### PR TITLE
During release, only upgrade pip when needed

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -33,9 +33,9 @@ for python in python{2,3}; do
     set +u
     source "${venv}/bin/activate"
     set -u
+    pip install --upgrade --quiet pip
     for dist in dist/*; do
         ls "${dist}"
-        pip install --quiet -U pip
         pip install --quiet "${dist}"
         python -c "import testimony" 1>/dev/null
         make test


### PR DESCRIPTION
The `pip` package may be out of date when a virtualenv is first created.
Thus, after creating and activating a virtualenv, it's a good idea to
execute `pip install --upgrade pip`. However, the `release.sh` script
upgrades pip every time testimony is installed. Let's be nicer to PyPi
by only updating pip after each virtualenv is first created.