### PR TITLE
List all requirements in setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
-termcolor
+# "Now your `pip install -r requirements.txt` will work just as before. It will
+# first install the library located at the file path `.` and then move on to
+# its abstract dependencies"
+#
+# See: https://caremad.io/2013/07/setup-vs-requirement/
 
+--editable .

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author='Suresh Thirugn',
     author_email='sthirugn@redhat.com',
     packages=find_packages(),
-    install_requires=['Click'],
+    install_requires=['Click', 'termcolor'],
     entry_points='''
         [console_scripts]
         testimony=testimony.cli:testimony


### PR DESCRIPTION
Pure-python packages should list all dependences in `setup.py`. If this
is done, then eggs and wheels will properly list all dependencies needed
to use the package.

Dependencies listed in `requirements.txt` are not included in eggs or
wheels.