### PR TITLE
Add "help" target to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,12 @@
+help:
+	@echo "Please use \`make <target>', where <target> is one of"
+	@echo "  help           to show this message"
+	@echo "  lint           to check the codebase for errors"
+	@echo "  package        to generate installable Python packages"
+	@echo "  package-clean  to remove generated Python packages"
+	@echo "  publish        to upload dist/* to PyPi"
+	@echo "  test           to run unit tests"
+
 lint:
 	flake8 testimony
 
@@ -9,7 +18,8 @@ package-clean:
 
 publish: package
 	twine upload dist/*
+
 test:
 	@./tests/test_testimony.sh | diff tests/sample_output.txt -
 
-.PHONY: package package-clean publish test
+.PHONY: help lint package package-clean publish test


### PR DESCRIPTION
The new "help" target is listed first, and is therefore the new default
make target.

In addition, add "help" and "lint" to the list of phony make targets.