### PR TITLE
Improve validate-docstrings output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 sudo: false
 language: python
+python:
+    - "2.7"
+    - "3.4"
+    - "3.5"
 install: pip install -r requirements-dev.txt .
 script:
     - make lint

--- a/testimony/__init__.py
+++ b/testimony/__init__.py
@@ -277,7 +277,8 @@ def validate_docstring_report(testcases):
                 ))
                 invalid_tags_docstring_count += 1
             if issues:
-                result.setdefault(path, {})[testcase.name] = issues
+                result.setdefault(
+                    path, collections.OrderedDict())[testcase.name] = issues
                 invalid_docstring_count += 1
 
     if SETTINGS['json']:


### PR DESCRIPTION
Sort the test cases by name before showing the output. This will ensure the
same order for every run or Testimony since a dictionary is being used in order
to collect the issues an specific test case has. This is needed because on
Python 3 the dict hash have a random seed which produces different ordering
when reading its items.

Also make travis test against Python 2.7, 3.4 and 3.5. This will ensure the
test passing over all supported Python versions.

Close #114