### PR TITLE
Drop support to token_prefix option

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,13 +50,7 @@ minimum-tokens
 .. note::
 
     To help test case parsing, make sure that each test case docstring has the
-    tokens in the following format ``{token_prefix}token{token_suffix}``,
-    where:
-
-    token_prefix
-        This is configurable and by default, it is ``:``.
-    token_suffix
-        This is not configurable and should always be ``:``.
+    tokens in the following format ``:token:``.
 
 Sample Test Case
 ++++++++++++++++

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author='Suresh Thirugn',
     author_email='sthirugn@redhat.com',
     packages=find_packages(),
-    install_requires=['Click', 'termcolor'],
+    install_requires=['Click', 'termcolor', 'docutils'],
     entry_points='''
         [console_scripts]
         testimony=testimony.cli:testimony

--- a/testimony/__init__.py
+++ b/testimony/__init__.py
@@ -83,7 +83,6 @@ class TestFunction(object):
         self.parser = DocstringParser(
             SETTINGS.get('tokens'),
             SETTINGS.get('minimum_tokens'),
-            SETTINGS.get('token_prefix', ':'),
         )
         self._parse_docstring()
 

--- a/testimony/cli.py
+++ b/testimony/cli.py
@@ -5,14 +5,6 @@ import click
 from testimony import SETTINGS, constants, main
 
 
-def _validate_token_prefix(ctx, param, value):
-    """Ensure single character for token prefix."""
-    if len(value) != 1:
-        raise click.BadParameter('token prefix should be a single character.')
-    else:
-        return value
-
-
 @click.command()
 @click.option('-j', '--json', help='JSON output', is_flag=True)
 @click.option('-n', '--nocolor', default=False, help='Color output',
@@ -20,21 +12,14 @@ def _validate_token_prefix(ctx, param, value):
 @click.option('--tokens', help='Comma separated list of expected tokens')
 @click.option(
     '--minimum-tokens', help='Comma separated list of minimum expected tokens')
-@click.option(
-    '--token-prefix',
-    callback=_validate_token_prefix,
-    default=':',
-    help='Single character token prefix'
-)
 @click.argument('report', type=click.Choice(constants.REPORT_TAGS))
 @click.argument('path', nargs=-1, type=click.Path(exists=True))
 def testimony(
-        json, nocolor, tokens, minimum_tokens, token_prefix, report, path):
+        json, nocolor, tokens, minimum_tokens, report, path):
     """Inspect and report on the Python test cases."""
     if tokens:
         SETTINGS['tokens'] = [token.strip() for token in tokens.split(',')]
     if minimum_tokens:
         SETTINGS['minimum_tokens'] = [
             token.strip() for token in minimum_tokens.split(',')]
-    SETTINGS['token_prefix'] = token_prefix
     main(report, path, json, nocolor)

--- a/testimony/parser.py
+++ b/testimony/parser.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 """Docstring parser utilities for Testimony."""
-import re
 from docutils.core import publish_string
 from xml.etree import ElementTree
 
@@ -10,7 +9,7 @@ from testimony.constants import DEFAULT_MINIMUM_TOKENS, DEFAULT_TOKENS
 class DocstringParser(object):
     """Parse docstring extracting tokens."""
 
-    def __init__(self, tokens=None, minimum_tokens=None, prefix=':'):
+    def __init__(self, tokens=None, minimum_tokens=None):
         """Initialize the parser with expected tokens and the minimum set."""
         if tokens is None:
             self.tokens = DEFAULT_TOKENS
@@ -20,13 +19,8 @@ class DocstringParser(object):
             self.minimum_tokens = DEFAULT_MINIMUM_TOKENS
         else:
             self.minimum_tokens = minimum_tokens
-        self.token_prefix = prefix
         self.minimum_tokens = set(self.minimum_tokens)
         self.tokens = set(self.tokens)
-        self.token_regex = re.compile(
-            r'^{0}(\w+):\s+([^{0}]+)(\n|$)'.format(self.token_prefix),
-            flags=re.MULTILINE
-        )
         if not self.minimum_tokens.issubset(self.tokens):
             raise ValueError('tokens should contain minimum_tokens')
 
@@ -58,31 +52,28 @@ class DocstringParser(object):
         valid_tokens = {}
         invalid_tokens = {}
 
-        if self.token_prefix == ':':
-            docstring_xml = publish_string(docstring, writer_name='xml')
-            root = ElementTree.fromstring(docstring_xml)
-            tokens = root.findall('./field_list/field')
-            for token in tokens:
-                token_name = token.find('./field_name').text.lower()
-                value_el = token.find('./field_body/')
-                if value_el is None:
-                    invalid_tokens[token_name] = ''
-                    continue
-                if value_el.tag == 'paragraph':
-                    value = value_el.text
-                if value_el.tag == 'enumerated_list':
-                    value_lst = map(lambda elem: elem.text,
-                                    value_el.findall('./list_item/paragraph'))
-                    list_enum = list(enumerate(value_lst, start=1))
-                    steps = map(lambda val: '{}. {}'.format(val[0], val[1]),
-                                list_enum)
-                    value = '\n'.join(steps)
-                tokens_dict[token_name] = value
-        else:
-            for match in self.token_regex.finditer(docstring):
-                token = match.group(1).strip().lower()
-                value = match.group(2).strip()
-                tokens_dict[token] = value
+        # Parse the docstring with the docutils RST parser and output the
+        # result as XML, this ease the process of getting the tokens
+        # information.
+        docstring_xml = publish_string(docstring, writer_name='xml')
+        root = ElementTree.fromstring(docstring_xml)
+        tokens = root.findall('./field_list/field')
+        for token in tokens:
+            token_name = token.find('./field_name').text.lower()
+            value_el = token.find('./field_body/')
+            if value_el is None:
+                invalid_tokens[token_name] = ''
+                continue
+            if value_el.tag == 'paragraph':
+                value = value_el.text
+            if value_el.tag == 'enumerated_list':
+                value_lst = map(lambda elem: elem.text,
+                                value_el.findall('./list_item/paragraph'))
+                list_enum = list(enumerate(value_lst, start=1))
+                steps = map(lambda val: '{}. {}'.format(val[0], val[1]),
+                            list_enum)
+                value = '\n'.join(steps)
+            tokens_dict[token_name] = value
 
         for token, value in tokens_dict.items():
             if token in self.tokens:

--- a/tests/sample_output.txt
+++ b/tests/sample_output.txt
@@ -16,6 +16,7 @@ Setup:
 
 Steps:
  1. Login to the application with valid credentials
+ 2. Add a colon to the steps token: it should appear.
 
 Tags:
  t1, t2, t3
@@ -145,7 +146,8 @@ Setup:
  Global setup
 
 Steps:
- 1. Login to the application with valid username and no password
+ 1. Login to the application with valid username
+ and no password
 
 Test:
  Login with invalid credentials

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -20,9 +20,8 @@ class Testsample1():
 
         :Feture: Login - Positive
 
-        :Steps:
-
-        1. Login to the application with valid credentials
+        :Steps: 1. Login to the application with valid credentials
+                2. Add a colon to the steps token: it should appear.
 
         :Assert: Login is successful
 
@@ -50,14 +49,11 @@ class Testsample1():
 
         :Feature: Login - Positive
 
-        :Steps:
-
-        1. Login to the application with valid Latin credentials
+        :Steps: 1. Login to the application with valid Latin credentials
 
         :Assert: Login is successful
 
         :Tags: t1
-
         """
         # Code to perform the test
         pass
@@ -68,15 +64,12 @@ class Testsample1():
 
         :Feature: Login - Positive
 
-        :Steps:
-
-        1. Login to the application with valid credentials having
-        special characters
+        :Steps: 1. Login to the application with valid credentials having
+                   special characters
 
         :Assert: Activation key is created
 
         :Status: Manual
-
         """
         # Code to perform the test
         pass
@@ -85,9 +78,7 @@ class Testsample1():
     def test_negative_login_5(self):
         """Test missing required docstrings
 
-        :Steps:
-
-        1. Login to the application with invalid credentials
+        :Steps: 1. Login to the application with invalid credentials
 
         :BZ: 123456
 
@@ -109,9 +100,7 @@ class Testsample2():
 
         :Feature: Login - Negative
 
-        :Steps:
-
-        1. Login to the application with invalid credentials
+        :Steps: 1. Login to the application with invalid credentials
 
         :Assert: Login failed
 
@@ -137,12 +126,10 @@ class Testsample3():
 
         :Feature: Login - Negative
 
-        :Steps:
-
-        1. Login to the application with valid username and no password
+        :Steps: 1. Login to the application with valid username
+                   and no password
 
         :Assert: Login failed
-
         """
         # Code to perform the test
         pass


### PR DESCRIPTION
Only accept `:token:` as valid token. That format is recognized by RST as field-list which will give a great output if documentation of the test suite is generated using Sphinx.

This PR takes #122, squashes all commits in there and add an additional commit to drop the support to the token_prefix option.

Close #122 
