### PR TITLE
Add support for reading package __init__.py files

### DIFF
--- a/testimony/__init__.py
+++ b/testimony/__init__.py
@@ -78,6 +78,14 @@ class TestFunction(object):
         self.testmodule = testmodule.path
         self.module_def = testmodule
         self.module_docstring = ast.get_docstring(self.module_def)
+        self.pkgdir = os.path.dirname(self.testmodule)
+        self.pkginit = os.path.join(self.pkgdir, '__init__.py')
+        if os.path.exists(self.pkginit):
+            self.pkginit_def = ast.parse(''.join(open(self.pkginit)))
+            self.pkginit_docstring = ast.get_docstring(self.pkginit_def)
+        else:
+            self.pkginit_def = None
+            self.pkginit_docstring = None
         self.tokens = {}
         self.invalid_tokens = {}
         self.parser = DocstringParser(
@@ -100,6 +108,7 @@ class TestFunction(object):
         # ensures that function docstring has more priority over class and
         # module docstrings respectively.
         docstrings = [
+            self.pkginit_docstring,
             self.module_docstring,
             self.class_docstring,
             self.docstring,

--- a/tests/sample_output.txt
+++ b/tests/sample_output.txt
@@ -153,22 +153,47 @@ Test:
  Login with invalid credentials
 
 
+tests/sample_pkg/test_sample2.py
+================================
+
+test_positive_login_3
+---------------------
+
+Assert:
+ Login is successful
+
+Feature:
+ Package Feature
+
+Setup:
+ Method setup
+
+Steps:
+ 1. Login to the application with valid Latin credentials
+
+Tags:
+ t1
+
+Test:
+ Login with Latin credentials
+
+
 
 ==================
 = summary report =
 ==================
 
-Total number of tests:          7
-Test cases with no docstrings:  1 (14.29%)
-Assert:                         5 (71.43%)
-Bz:                             2 (28.57%)
-Feature:                        4 (57.14%)
-Setup:                          6 (85.71%)
-Status:                         3 (42.86%)
-Steps:                          6 (85.71%)
-Tags:                           4 (57.14%)
-Test:                           6 (85.71%)
-Type:                           1 (14.29%)
+Total number of tests:          8
+Test cases with no docstrings:  1 (12.50%)
+Assert:                         6 (75.00%)
+Bz:                             2 (25.00%)
+Feature:                        5 (62.50%)
+Setup:                          7 (87.50%)
+Status:                         3 (37.50%)
+Steps:                          7 (87.50%)
+Tags:                           5 (62.50%)
+Test:                           7 (87.50%)
+Type:                           1 (12.50%)
 
 =============================
 = validate_docstring report =
@@ -198,8 +223,8 @@ test_negative_login_5
 
 * Docstring should have at least assert, feature, test token(s)
 
-Total number of tests: 7
-Total number of invalid docstrings: 3 (42.86%)
-Test cases with no docstrings: 1 (14.29%)
-Test cases missing minimal docstrings: 3 (42.86%)
-Test cases with invalid tags: 1 (14.29%)
+Total number of tests: 8
+Total number of invalid docstrings: 3 (37.50%)
+Test cases with no docstrings: 1 (12.50%)
+Test cases missing minimal docstrings: 3 (37.50%)
+Test cases with invalid tags: 1 (12.50%)

--- a/tests/sample_pkg/__init__.py
+++ b/tests/sample_pkg/__init__.py
@@ -1,0 +1,4 @@
+""" sample package __init__.py file
+
+:Feature:  Package Feature
+"""

--- a/tests/sample_pkg/test_sample2.py
+++ b/tests/sample_pkg/test_sample2.py
@@ -1,0 +1,28 @@
+# -*- encoding: utf-8 -*-
+"""Test Module for Package Sample Test
+
+:Setup: Global setup
+"""
+
+
+class TestPackage1():
+    """Test Class for Package Sample Test
+
+    :Setup: Class setup
+    """
+
+    # Test with Feature inherited from __init__.py
+    def test_positive_login_3(self):
+        """Login with Latin credentials
+
+        :Setup: Method setup
+
+        :Steps: 1. Login to the application with valid Latin credentials
+
+        :Assert: Login is successful
+
+        :Tags: t1
+        """
+        # Code to perform the test
+        pass
+


### PR DESCRIPTION
Read docstrings from a package __init__.py file and process
tokens for tests within the package directory.  It will allow
using __init__.py to define package level defaults for tokens.

This change is for issue #127.

Signed-off-by: Scott Poore <spoore@redhat.com>