### PR TITLE
Change JSON structure in `testimony print`

### DIFF
--- a/testimony/__init__.py
+++ b/testimony/__init__.py
@@ -298,13 +298,15 @@ def print_report(testcases):
             for test in tests:
                 test_dict = test.to_dict()
                 test_data = test_dict['tokens']
-                test_data['test-path'] = path
-                test_data['test-class'] = test.parent_class
-                test_data['test-name'] = test.name
-                test_data['testimony-invalid-tokens'] = test_dict[
+                testimony_metadata = {}
+                testimony_metadata['file-path'] = path
+                testimony_metadata['test-class'] = test.parent_class
+                testimony_metadata['test-name'] = test.name
+                testimony_metadata['invalid-tokens'] = test_dict[
                     'invalid-tokens']
-                test_data['testimony-rst-parse-messages'] = test_dict[
+                testimony_metadata['rst-parse-messages'] = test_dict[
                     'rst-parse-messages']
+                test_data['_testimony'] = testimony_metadata
                 result.append(test_data)
 
         print(json.dumps(result))

--- a/testimony/__init__.py
+++ b/testimony/__init__.py
@@ -292,22 +292,35 @@ def print_report(testcases):
     :param testcases: A dict where the key is a path and value is a list of
         found testcases on that path.
     """
+    if SETTINGS['json']:
+        result = []
+        for path, tests in testcases.items():
+            for test in tests:
+                test_dict = test.to_dict()
+                test_data = test_dict['tokens']
+                test_data['test-path'] = path
+                test_data['test-class'] = test.parent_class
+                test_data['test-name'] = test.name
+                test_data['testimony-invalid-tokens'] = test_dict[
+                    'invalid-tokens']
+                test_data['testimony-rst-parse-messages'] = test_dict[
+                    'rst-parse-messages']
+                result.append(test_data)
+
+        print(json.dumps(result))
+        return 0
+
     result = {}
     for path, tests in testcases.items():
         result[path] = [test.to_dict() for test in tests]
-        if not SETTINGS['json']:
-            print('{0}\n{1}\n'.format(
-                colored(path, attrs=['bold']), '=' * len(path)))
-            if len(tests) == 0:
-                print('No test cases found.\n')
-            for test in tests:
-                title = testcase_title(test)
-                print('{0}\n{1}\n\n{2}\n'.format(
-                    title, '-' * len(title), test))
-
-    if SETTINGS['json']:
-        print(json.dumps(result))
-        return 0
+        print('{0}\n{1}\n'.format(
+            colored(path, attrs=['bold']), '=' * len(path)))
+        if len(tests) == 0:
+            print('No test cases found.\n')
+        for test in tests:
+            title = testcase_title(test)
+            print('{0}\n{1}\n\n{2}\n'.format(
+                title, '-' * len(title), test))
 
 
 def summary_report(testcases):


### PR DESCRIPTION
`testimony --json print` was direct dump of internal testimony data structures. It was a little awkward to work with from external point of view.

- new structure is simplified - it's shallow list of objects with tokens and some additional fields
- include test name and class for each test case

GitHub diff view is misleading a bit, I moved ` if SETTINGS['json']:` part above main printing part.